### PR TITLE
Revert to binary mode for opening parenthood gzip file

### DIFF
--- a/parenthood_lib.py
+++ b/parenthood_lib.py
@@ -592,8 +592,8 @@ def parse_full_ec_file_to_transitive_parenthood(
 
 def get_applicable_label_dict(
     path = APPLICABLE_LABEL_JSON_PATH):
-  with tf.io.gfile.GFile(path, 'r') as f:
-    with gzip.GzipFile(fileobj=f, mode='r') as gzip_file:
+  with tf.io.gfile.GFile(path, 'rb') as f:
+    with gzip.GzipFile(fileobj=f, mode='rb') as gzip_file:
       return json.load(gzip_file)
 
 


### PR DESCRIPTION
I think the recent change (https://github.com/google-research/proteinfer/commit/5dbbc9979d1f69e5b76847f9b391078155f8ea43) broke opening of gzipped parenthood files. This appears to fix that by opening files in binary mode as previously.