### PR TITLE
gitignore cached modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cached_models/**


### PR DESCRIPTION
cached_models is the default installation path in install_models.py