### PR TITLE
Stop train_test trying to access fasta files as TFrecords

### DIFF
--- a/protein_dataset.py
+++ b/protein_dataset.py
@@ -161,7 +161,7 @@ def non_batched_dataset(train_dev_or_test,
   dataset_files = [
       os.path.join(data_root_dir, f)
       for f in tf.gfile.ListDirectory(data_root_dir)
-      if train_dev_or_test in f
+      if train_dev_or_test in f and ".tfrecord" in f
   ]
 
   tfrecord_dataset = tf.data.TFRecordDataset(dataset_files)


### PR DESCRIPTION
A weird test started failing last week. Think I've tracked it down. A file called `test_haemoglobin.fasta` was added to `testdata` but unfortunately one of our tests tries to read any file in `testdata` with `*test*` in the filename as a TF record file. This changes that (in the library code, not the test).