### PR TITLE
Learn more button should read 'less' when section is expanded

### DIFF
--- a/script.js
+++ b/script.js
@@ -1372,7 +1372,7 @@ function enableInteractions() {
 }
 
 function toggleHelpButtonText(button) {
-  if (button.text() == "Learn more") {
+  if (button.text().match(/more/)) {
     button.text("Less");
   } else {
     button.text("Learn more");


### PR DESCRIPTION
before the matching was not capturing when there was more whitespace between "learn" and "more"