### PR TITLE
Allows for substantially larger inputs for CLI

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -278,8 +278,7 @@ class Inferrer(object):
     Returns:
       concatenated numpy array of activations with shape [num_of_seqs, ...]
     """
-    import pdb; pdb.set_trace()
-    np_seqs = np.array(list_of_seqs, dtype=np.str_)
+    np_seqs = np.array(list_of_seqs, dtype=np.object)
     if np_seqs.size == 0:
       return np.array([], dtype=float)
 

--- a/inference.py
+++ b/inference.py
@@ -277,7 +277,8 @@ class Inferrer(object):
         uses default for signature.
 
     Returns:
-      concatenated numpy array of activations with shape [num_of_seqs, ...]
+      np.array of scipy sparse coo matrices of shape [num_of_seqs_in_batch, ...]
+      where ... is the shape of the fetch tensor.
     """
     np_seqs = np.array(list_of_seqs, dtype=np.object)
     if np_seqs.size == 0:

--- a/inference.py
+++ b/inference.py
@@ -131,7 +131,7 @@ def memoized_inferrer(
     savedmodel_dir_path,
     activation_type=tf.saved_model.signature_constants
     .DEFAULT_SERVING_SIGNATURE_DEF_KEY,
-    batch_size=64,
+    batch_size=16,
     use_tqdm=False,
     session_config=None,
     memoize_inference_results=False,
@@ -157,7 +157,7 @@ class Inferrer(object):
       savedmodel_dir_path,
       activation_type=tf.saved_model.signature_constants
       .DEFAULT_SERVING_SIGNATURE_DEF_KEY,
-      batch_size=64,
+      batch_size=16,
       use_tqdm=False,
       session_config=None,
       memoize_inference_results=False,

--- a/inference.py
+++ b/inference.py
@@ -278,6 +278,7 @@ class Inferrer(object):
     Returns:
       concatenated numpy array of activations with shape [num_of_seqs, ...]
     """
+    import pdb; pdb.set_trace()
     np_seqs = np.array(list_of_seqs, dtype=np.str_)
     if np_seqs.size == 0:
       return np.array([], dtype=float)


### PR DESCRIPTION
This CL allows for inputs that are a few million sequences (on a machine as suggested in the installation instructions).
The things that allow this:
- smaller batch size (limits GPU memory pressure in case of very long sequences)
- sparsify stored activations (that are later compared against a threshold)