### PR TITLE
hotfix: pin ngl to prevent everything from breaking

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 
   <script src="templatev2.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@2.0.0/dist/tf.min.js"></script>
-  <script src="https://unpkg.com/ngl"></script>
+  <script src="https://unpkg.com/ngl@0.10.4"></script>
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <!--Has to go after plotly because plotly overrides Promise https://github.com/plotly/plotly.js/issues/1032 -->
   <script src="//cdn.jsdelivr.net/npm/bluebird@3.5.5/js/browser/bluebird.min.js"></script>


### PR DESCRIPTION
Was just alerted to this issue. Hotfix for now. 